### PR TITLE
Fix a bug in varchar without CHARACTER_MAXIMUM_LENGTH set

### DIFF
--- a/mssql2mysql.php
+++ b/mssql2mysql.php
@@ -122,11 +122,11 @@ if (!empty($mssql_tables))
 
 					case 'nchar':
 					case 'char':
-						$data_type = 'char'.(!empty($row['CHARACTER_MAXIMUM_LENGTH']) && $row['CHARACTER_MAXIMUM_LENGTH'] > 0 ? '('.$row['CHARACTER_MAXIMUM_LENGTH'].')' : '255' );
+						$data_type = 'char'.(!empty($row['CHARACTER_MAXIMUM_LENGTH']) && $row['CHARACTER_MAXIMUM_LENGTH'] > 0 ? '('.$row['CHARACTER_MAXIMUM_LENGTH'].')' : '(255)' );
 						break;
 					case 'nvarchar':
 					case 'varchar':
-						$data_type = 'varchar'.(!empty($row['CHARACTER_MAXIMUM_LENGTH']) && $row['CHARACTER_MAXIMUM_LENGTH'] > 0 ? '('.$row['CHARACTER_MAXIMUM_LENGTH'].')' : '255' );
+						$data_type = 'varchar'.(!empty($row['CHARACTER_MAXIMUM_LENGTH']) && $row['CHARACTER_MAXIMUM_LENGTH'] > 0 ? '('.$row['CHARACTER_MAXIMUM_LENGTH'].')' : '(255)' );
 						break;
 					case 'ntext':
 					case 'text':


### PR DESCRIPTION
The script generates broken queries:  `varchar255` instead of `varchar(255)`
